### PR TITLE
Log request-id if present

### DIFF
--- a/src/aclaimant/paper_pusher/service.clj
+++ b/src/aclaimant/paper_pusher/service.clj
@@ -168,17 +168,25 @@
     (str pdf-url "?key=" request-key)
     pdf-url))
 
+(defn log-request
+  "Logs the pdf url and an optional request-id."
+  [route {:keys [pdf-url request-id]}]
+  (println (format "[%s] %s: %s" (or request-id "") route pdf-url)))
+
 (defroutes protected-routes
   (POST "/paper-pusher/push" {params :params}
+    (log-request "push" params)
     {:status 200
      :headers {"Content-Type" "application/pdf"}
      :body (with-field-values (pdf-url params) (:values params))})
   (POST "/paper-pusher/preview" {params :params}
+    (log-request "preview" params)
     (let [pdf-url (pdf-url params)]
       {:status 200
        :headers {"Content-Type" "application/pdf"}
        :body (preview-fields pdf-url)}))
   (POST "/paper-pusher/form-fields" {params :params}
+    (log-request "form-fields" params)
     (let [pdf-url (pdf-url params)]
       {:status 200
        :headers {"Content-Type" "application/edn"}


### PR DESCRIPTION
tracing from service to is difficult so adding request-id helps in
cross-referencing in logs.

Furthermore, we get when the request is received and then our nginx
logs log when the request is handled so we can trace potential
bottlenecks in service  -> paper-pusher -> service -> paper-pusher ->
service shenanigans of getting the skeleton for a fillable pdf.

for those playing along at home:
    service (ask for generator info)
 -> paper-pusher (pdf url)
 -> service (s3 pdf location)
 -> paper-pusher (pdf bytes and parses to get skeleton)
 -> service

Co-authored-by: Sean Vincent <sean.vincent@aclaimant.com>

## Description of the change

> Description here

## Type of change
- [ ] Bug fix
- [ ] Enhancement
