### PR TITLE
[OWL-10329] Handle InvalidPdfExceptions by returning a status code 415 (Unsupported Media Type)

### DIFF
--- a/src/aclaimant/paper_pusher/service.clj
+++ b/src/aclaimant/paper_pusher/service.clj
@@ -9,6 +9,7 @@
   (:import
     [com.itextpdf.text.pdf AcroFields BaseFont PdfReader PdfStamper PdfContentByte ColumnText PdfString PdfName PdfAnnotation PdfContentByte]
     [com.itextpdf.text Paragraph Rectangle Element Phrase BaseColor]
+    [com.itextpdf.text.exceptions InvalidPdfException]
     [java.io ByteArrayOutputStream ByteArrayInputStream]
     [org.apache.commons.io IOUtils]))
 
@@ -250,6 +251,11 @@
   (fn [e]
     (try
       (handler e)
+      (catch InvalidPdfException ex
+        (println "An error has occurred" (.getMessage ex))
+        (.printStackTrace ex)
+        {:status 415
+         :body "Unsupported PDF format. Perhaps it is encrypted or corrupted."})
       (catch Throwable ex
         (println "An error has occurred" (.getMessage ex))
         (.printStackTrace ex)


### PR DESCRIPTION
There's not types of PDF encryption that the version of iText we're using doesn't support. Update to the latest iText would resolve this, but unfortunately they've made significant breaking changes to their API. Updating would be re-writing the meat of paper pusher.

This PR, just explicitly handles these errors and provides an explicit error message about what the problem is. This will allow root users to inspect their PDF formats and if there's an unsupported encryption method it can be removed with Adobe Acrobat.